### PR TITLE
Comment said that the event files aren't working so this should fix them

### DIFF
--- a/events/Cardolan.txt
+++ b/events/Cardolan.txt
@@ -25,7 +25,6 @@ country_event = {
 	
 	option = { 
 		name = cardolan.1.a
-		trigger = { is_ai = no }
 		#TODO send event to Isengard about this
 		#TODO send event to mordor about this
 	}

--- a/events/Gondor.txt
+++ b/events/Gondor.txt
@@ -74,7 +74,6 @@ country_event = {
 
 	option = { # Accept
 		name = gondor.2.a
-		trigger = { is_ai = no }
 		random_list = {
 			50 = { 
 				if = { limit = { NOT = { has_global_flag = fs_gondor_2 } NOT = { has_global_flag = boromir_dead } } remove_unit_leader = 4002 set_global_flag = boromir_dead news_event = { hours = 12 id = news.379 } }  
@@ -111,7 +110,6 @@ country_event = {
 
 	option = { # Accept
 		name = gondor.3.a
-		trigger = { is_ai = no }
 		set_global_flag = denethor_dead
 		kill_country_leader = yes
 		news_event = { hours = 12 id = news.381 }

--- a/events/Mirkwood.txt
+++ b/events/Mirkwood.txt
@@ -170,7 +170,6 @@ country_event = {
 	
 	option = { 
 		name = mirkwood.4.a
-		trigger = { is_ai = no }
 		set_global_flag = mirkwood_spider_warning
 		add_manpower = -60000
 		823 = { remove_core_of = MEN }
@@ -215,7 +214,6 @@ country_event = {
 	
 	option = { 
 		name = mirkwood.5.a
-		trigger = { is_ai = no }
 		set_global_flag = mirkwood_spider_attack
 		SPR = {
 			add_state_core = 823
@@ -262,7 +260,6 @@ country_event = {
 	
 	option = { 
 		name = mirkwood.6.a
-		trigger = { is_ai = no }
 		set_global_flag = mirkwood_dolguldur_warning
 		add_manpower = -80000
 		828 = { remove_core_of = MEN }
@@ -302,7 +299,6 @@ country_event = {
 	
 	option = { 
 		name = mirkwood.7.a
-		trigger = { is_ai = no }
 		set_global_flag = mirkwood_dolguldur_attack
 		GUA = {
 			add_state_core = 828

--- a/events/Mordor.txt
+++ b/events/Mordor.txt
@@ -17,7 +17,6 @@ country_event = {
 
 	option = { # Support Sauron
 		name = mordor.1.a
-		trigger = { is_ai = no }
 		set_global_flag = mordor_civil_war
 		hidden_effect = {
 			unlock_national_focus = submittosauron

--- a/events/Moria.txt
+++ b/events/Moria.txt
@@ -26,7 +26,7 @@ country_event = {
 
 	option = { # Support Dwarves
 		name = moria.1.a
-		trigger = { is_ai = no }
+				ai_chance = {base = 10}
 		remove_unit_leader = 6001
 		set_global_flag = moria_civil_war
 		ECU = { country_event = { days = 2 id = moria.2 } }
@@ -66,7 +66,7 @@ country_event = {
 
 	option = { # Support Orcs
 		name = moria.1.b
-		trigger = { is_ai = no }
+		ai_chance = {base = 10}
 		remove_unit_leader = 6001
 		set_global_flag = moria_civil_war
 		ECU = { country_event = { days = 2 id = moria.2 } }

--- a/events/Rivendell.txt
+++ b/events/Rivendell.txt
@@ -25,7 +25,6 @@ country_event = {
 	
 	option = { 
 		name = rivendell.1.a
-		trigger = { is_ai = no }
 		set_global_flag = fellowship_departed
 		hidden_effect = {
 			news_event = { hours = 24 id = news.332 }

--- a/events/Rohan.txt
+++ b/events/Rohan.txt
@@ -109,7 +109,6 @@ country_event = {
 	
 	option = { 
 		name = rohan.4.a
-		trigger = { is_ai = no }
 		remove_unit_leader = 1002
 		hidden_effect = {news_event = { hours = 48 id = news.336 }}
 	}
@@ -161,7 +160,6 @@ country_event = {
 	
 	option = { 
 		name = rohan.2.a
-		trigger = { is_ai = no }
 		set_politics = { ruling_party = neutrality elections_allowed = no } 
 		remove_unit_leader = 1000
 		hidden_effect = { news_event = { hours = 48 id = news.337 } }
@@ -183,7 +181,7 @@ country_event = {
 	
 	option = { 
 		name = rohan.3.a
-		trigger = { is_ai = no }
+		
 		add_manpower = -20000
 		remove_unit_leader = 1001
 	}
@@ -204,7 +202,6 @@ country_event = {
 	
 	option = { 
 		name = rohan.7.a
-		trigger = { is_ai = no }
 		set_global_flag = grima_eowyn_married
 		hidden_effect = { news_event = { hours = 48 id = news.338 } }
 	}

--- a/events/Shire.txt
+++ b/events/Shire.txt
@@ -24,7 +24,6 @@ country_event = {
 	
 	option = { 
 		name = shire.1.a
-		trigger = { is_ai = no }
 		hidden_effect = {news_event = { hours = 24 id = news.331 }}
 	}
 	

--- a/events/StartEvent.txt
+++ b/events/StartEvent.txt
@@ -15,13 +15,9 @@ country_event = {
 		NOT = { has_country_flag = tutorial_shown }
 	}
 
-	mean_time_to_happen = {
-		days = 1
-	}
 
 	option = { # Accept
 		name = gamestart.1.a
-		trigger = { is_ai = no }
 		add_political_power = 1
 		set_country_flag = tutorial_shown
 	}


### PR DESCRIPTION
Events that had {is_ai = no} inside of the trigger for the option would not fire at all. Removed this and the ai will automatically select the top option. Most of these only had one option so they work fine. Moria did need ai_chance so I just put it at an equal chance for either option to happen. I think at some point an update made it so that is_ai = no broke the events. Not sure why they were in there anyway but I think it should be fine without them.